### PR TITLE
Added per GPU nThread limit based on memory

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -389,6 +389,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-G", _("Enable GPU mining (default: false)"));
     strUsage += HelpMessageOpt("-device=<id>", _("If -G is enabled this specifies the GPU device number to use (default: 0)"));
     strUsage += HelpMessageOpt("-allgpu", _("If -G is enabled this will mine on all available GPU devices (default: false)"));
+    strUsage += HelpMessageOpt("-forcenolimit", _("Do not limit thread count per GPU by memory limits. (default: false)"));
 #endif
     strUsage += HelpMessageOpt("-help-debug", _("Show all debugging options (usage: --help -help-debug)"));
     strUsage += HelpMessageOpt("-logips", strprintf(_("Include IP addresses in debug output (default: %u)"), 0));
@@ -1501,6 +1502,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
  		   conf.useGPU = GetBoolArg("-G", false) || GetBoolArg("-GPU", false);
  		   conf.selGPU = GetArg("-deviceid", 0);
  		   conf.allGPU = GetBoolArg("-allgpu", 0);
+ 		   conf.forceGenProcLimit = GetBoolArg("-forcenolimit", false);
        GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain, GetArg("-genproclimit", 1),conf);
       }
 #endif

--- a/src/libgpusolver/gpuconfig.h
+++ b/src/libgpusolver/gpuconfig.h
@@ -33,6 +33,7 @@ public:
 	bool useGPU;
 	unsigned selGPU;
 	bool allGPU;
+        bool forceGenProcLimit;
 	unsigned currentPlatform;
 	unsigned currentDevice;
 	unsigned globalWorkSize;

--- a/src/libgpusolver/libclwrapper.h
+++ b/src/libgpusolver/libclwrapper.h
@@ -79,6 +79,8 @@ public:
 	static unsigned getNumPlatforms();
 	static unsigned getNumDevices(unsigned _platformId = 0);
 	static std::string platform_info(unsigned _platformId = 0, unsigned _deviceId = 0);
+	static std::vector<cl::Device> getDevices(std::vector<cl::Platform> const& _platforms, unsigned _platformId);
+	static std::vector<cl::Platform> getPlatforms();
 	static void listDevices();
 
 	// Currently just prints memory of the GPU
@@ -112,8 +114,6 @@ private:
   static const size_t z_collision_bit_length = z_n / (z_k + 1);
   static const eh_index z_N = 1 << (z_collision_bit_length + 1);
 
-	static std::vector<cl::Device> getDevices(std::vector<cl::Platform> const& _platforms, unsigned _platformId);
-	static std::vector<cl::Platform> getPlatforms();
 	int compare_indices32(uint32_t* a, uint32_t* b, size_t n_current_indices) {
 		for(size_t i = 0; i < n_current_indices; ++i, ++a, ++b) {
 		    if(*a < *b) {


### PR DESCRIPTION
Limit the max number of threads specified by GenProcLimit that may be used per GPU based on memory constraints. This automates threading on multiple GPU rigs with different amounts of memory. 

GenProcLimit sets the max number of potential threads to use across all GPUs. It is still possible to limit all GPUs to 1 thread by setting GenProcLimit to 1.

GPUs with 2GB of memory, will only run 1 thread while GPUs with 4GB will be allowed to run 2 threads. GPUs with 8GB are allow 4 threads.

You may use "zcashd -forcenolimit" to ignore these memory constraints and honor GenProcLimit across all GPUs. This may leed to "out of memory" errors on your GPU.
