### PR TITLE
Only display OpenCL messages if DEBUG is defined

### DIFF
--- a/src/libgpusolver/libclwrapper.cpp
+++ b/src/libgpusolver/libclwrapper.cpp
@@ -36,6 +36,8 @@ unsigned cl_gpuminer::s_msPerBatch = cl_gpuminer::c_defaultMSPerBatch;
 unsigned cl_gpuminer::s_workgroupSize = cl_gpuminer::c_defaultLocalWorkSize;
 unsigned cl_gpuminer::s_initialGlobalWorkSize = cl_gpuminer::c_defaultGlobalWorkSizeMultiplier * cl_gpuminer::c_defaultLocalWorkSize;
 
+#ifdef DEBUG
+
 #if defined(_WIN32)
 extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char* lpOutputString);
 static std::atomic_flag s_logSpin = ATOMIC_FLAG_INIT;
@@ -51,6 +53,12 @@ static std::atomic_flag s_logSpin = ATOMIC_FLAG_INIT;
 	} while (false)
 #else
 #define CL_LOG(_contents) cout << "[OPENCL]:" << _contents << endl
+#endif
+
+#else
+
+#define CL_LOG(_contents) do{} while(false)
+
 #endif
 
 // Types of OpenCL devices we are interested in


### PR DESCRIPTION
There is probably a better way then my dumb "do {} while(false)" attempt at an empty stub for CL_LOG(_content)